### PR TITLE
Add BadRequest status code to response on ReturnModelStateAsJsonModelValidationFilter.OnActionExecuting error

### DIFF
--- a/src/Backend.Fx.AspNet/Mvc/Validation/ReturnModelStateAsJsonModelValidationFilter.cs
+++ b/src/Backend.Fx.AspNet/Mvc/Validation/ReturnModelStateAsJsonModelValidationFilter.cs
@@ -1,4 +1,5 @@
-﻿using Backend.Fx.AspNet.ErrorHandling;
+using System.Net;
+using Backend.Fx.AspNet.ErrorHandling;
 using Backend.Fx.Exceptions;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Backend.Fx.AspNet/Mvc/Validation/ReturnModelStateAsJsonModelValidationFilter.cs
+++ b/src/Backend.Fx.AspNet/Mvc/Validation/ReturnModelStateAsJsonModelValidationFilter.cs
@@ -21,6 +21,7 @@ public class ReturnModelStateAsJsonModelValidationFilter : ModelValidationFilter
         var errors = context.ModelState.ToErrorsDictionary();
         LogErrors(context, context.Controller.ToString() ?? "UnknownController", errors);
         context.Result = CreateResult(errors);
+        context.HttpContext.Response.StatusCode = (int)HttpStatusCode.BadRequest;
     }
 
     protected virtual IActionResult CreateResult(Errors errors)


### PR DESCRIPTION
At the moment, when a request is sent with an invalid model (e.g. a required field is missing), the response body is correctly filled, but the response status code is never set, and is `200`. This PR sets the status code to be `400`, as advertised.